### PR TITLE
fix(itf-factory): auto-populate NVS defaults and robustify web input validation

### DIFF
--- a/.agents/skills/esp-development/SKILL.md
+++ b/.agents/skills/esp-development/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: esp-development
+description: ESP32 hardware and ESP-IDF firmware development conventions, build commands, version-aware virtual environment setup, target-specific strapping GPIO checks, dependency matrix tracking, and MCP server integrations.
+---
+
+# ESP32 & ESP-IDF Development Skill
+
+## 1. MCP Server Discovery & Protocol
+
+Before executing build commands or researching ESP-IDF APIs:
+
+1. **ESP Documentation MCP Server (`espressif-docs`)**:
+   - Check if the `espressif-docs` MCP server is available.
+   - When available, ALWAYS use `search_espressif_sources` as the primary reference for documentation, SDK configuration options (`sdkconfig`), target-specific hardware details, and API signatures.
+
+2. **ESP-IDF Build MCP Server**:
+   - Check if an ESP-IDF Build / Tooling MCP server is active in the session context.
+   - If available, prefer using its native MCP tools for building, flashing, erasing, and target configuration over manual shell invocation.
+
+---
+
+## 2. ESP-IDF Version & Virtual Environment Matrix
+
+Workflows differ depending on the target ESP-IDF framework version line:
+
+### Case A: Anterior to v5.5 (`< v5.5`)
+- **Environment Setup**: Standard legacy exported environment. Ensure `. $IDF_PATH/export.sh` or standard Python virtual environment (`$IDF_TOOLS_PATH`) is sourced.
+- **Build Commands**:
+  - Set Target: `idf.py set-target <target>` (e.g. `esp32`, `esp32s3`, `esp32c3`)
+  - Build: `idf.py build`
+  - Flash: `idf.py -p PORT flash`
+  - Monitor: `idf.py -p PORT monitor`
+
+### Case B: Posterior to v5.5 (`>= v5.5` & `< v6.0`)
+- **Environment Setup**:
+  1. Check if an ESP-IDF Build MCP server is present. If so, invoke build/flash actions via MCP tools.
+  2. If Build MCP server is absent, use `eim run "idf.py fullclean build"` from project root (`BypassSandbox: true`) or standard exported shell environment (`. $IDF_PATH/export.sh`).
+- **Build Commands**: Standard `idf.py fullclean build` CLI workflow with modern ESP-IDF v5 component manager and CMake conventions.
+
+### Case C: Above or Equal to v6.0 (`>= v6.0`)
+- **Environment Setup**:
+  1. Check if an ESP-IDF Build MCP server is available. If present, use MCP tools.
+  2. **If Build MCP Server is NOT Available**: Use `eim` (Espressif Installation Manager) as the virtual environment manager for setting up and executing `idf.py`.
+     - Execute commands via `eim` from project root in `BypassSandbox: true` mode: `eim run "idf.py fullclean build"`.
+- **Build Commands**: `eim run "idf.py fullclean build"` (or native MCP tools when present).
+
+---
+
+## 3. Mandatory Build Rules & Subagent Protocol
+
+### Kconfig & `sdkconfig` Mandatory `fullclean` Rule
+- If any `Kconfig`, `Kconfig.projbuild`, `sdkconfig`, or `sdkconfig.*` defaults/override file is added, modified, or deleted, a `fullclean` build (`idf.py fullclean build` or `eim run "idf.py fullclean build"`) is **strictly mandatory** before building to ensure CMake cache re-evaluation.
+
+### Multi-Agent Subagent Execution & Build Rules
+- **Sequential Build Enforcement**: Subagents are strictly prohibited from executing build commands concurrently. Any control/verification builds must be run sequentially or yielded to the parent overseer agent.
+- **Workspace & Branch Boundaries**: Subagents must stay within project root workspace boundaries and operate on isolated feature branches.
+
+### Pre-Build Clean Protocol (`fullclean`)
+Before executing initial builds at session start or immediately after switching Git branches:
+- **Direct CLI / eim**: Run `idf.py fullclean` (or `eim run "idf.py fullclean" <env>`) before `idf.py build`.
+- **ESP Build MCP Server**: Invoke the clean build tool action prior to running target builds to purge stale CMake cache and generated Kconfig headers.
+
+---
+
+## 3. Key Hardware, Firmware & Scope Checklists
+
+### Pre-Build Session & Branch Switch Clean Checklist
+- [ ] Run `idf.py fullclean` (or `eim run "idf.py fullclean" <env>`) at the start of a session or after a branch switch before attempting `idf.py build`.
+
+### Agent Scope & Constraint Verification
+- Check for existing `REQUIREMENTS.md` and `CONSTRAINTS.md` files in the repository root. Ensure code modifications conform to declared architecture limits and operational scope.
+
+### Task Stack Allocation
+- Verify FreeRTOS stack allocation sizes. Recommended minimum task stack: **2048 to 4096 bytes** for tasks performing C standard library formatting (`printf`/`sprintf`), file system operations, or networking.
+
+### Target-Specific Strapping GPIO Verification
+- **Do NOT apply a generic blanket list of strapping pins across all chip architectures.**
+- Verify pin assignments against the **specific MCU build target**:
+  - **ESP32 (Original)**: Strapping pins are GPIO 0, 2, 5, 12, 15.
+  - **ESP32-S2**: Strapping pins are GPIO 0, 26, 45, 46.
+  - **ESP32-S3**: Strapping pins are GPIO 0, 3, 45, 46.
+  - **ESP32-C3**: Strapping pins are GPIO 2, 8, 9.
+  - **ESP32-C6**: Strapping pins are GPIO 8, 9, 15.
+  - **ESP32-H2**: Strapping pins are GPIO 8, 9, 25.
+- Avoid using target-specific strapping pins for pull-up/pull-down critical hardware signals, buttons, or external SPI/I2C buses that could prevent normal booting or force bootloader mode.
+- Use `search_espressif_sources` (via `espressif-docs` MCP server) to look up hardware datasheets and technical reference manuals for target-specific strapping pin configurations.
+
+### External Dependency Matrix Audit
+- For multi-subproject repositories using ESP-IDF component manager (`idf_component.yml`), verify that the top-level repository `README.md` maintains a structured dependency summary table listing each sub-project, invoked packages, exact installed versions from `dependencies.lock`/`managed_components`, and version constraints.

--- a/.agents/skills/esp-idf-v5-5-compile/SKILL.md
+++ b/.agents/skills/esp-idf-v5-5-compile/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: esp-idf-v5-5-compile
+description: Skill to configure, build, and qualitatively analyze ESP-IDF projects using framework versions between v5.5.x (included) and v6.x (excluded). Includes support for export.sh, eim tool manager, MCP servers, and standardized build diagnostic reporting.
+---
+
+# ESP-IDF v5.5.x Compilation & Qualitative Analysis Skill
+
+This skill provides step-by-step guidance for configuring, compiling, and qualitatively analyzing ESP-IDF firmware projects targeting **ESP-IDF v5.5.x up to v6.0 (excluded)**.
+
+---
+
+## 1. Environment Discovery & Setup
+
+Before running compilation, determine the active environment mode in order of preference:
+
+### Mode A: ESP-IDF Build MCP Server (Preferred if present)
+If an ESP-IDF Build MCP server is active in the environment, use its native build tools instead of direct shell commands.
+
+### Mode B: Espressif Installation Manager (`eim`)
+If `eim` is installed and managing ESP-IDF toolchains:
+1. Execute commands prefixed with `eim` from the project root directory:
+   ```bash
+   # Single-step clean & build execution from project root:
+   eim run "idf.py fullclean build"
+   ```
+2. **Sandbox Requirement**: Because `eim` accesses toolchain binaries and configurations stored in `~/.espressif` (outside the standard workspace sandbox), invoking `eim` commands requires running in **sandbox bypass mode** (`BypassSandbox: true`).
+
+---
+
+## 2. Compilation Workflow
+
+Execute the build sequence using the appropriate environment wrapper (`eim run "..."` or direct `idf.py`):
+
+1. **Set Target MCU Architecture** (if changing or initializing target):
+   ```bash
+   idf.py set-target <target_mcu>
+   # Supported targets: esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2, esp32p4
+   ```
+
+2. **Clean Build Execution**:
+   > [!IMPORTANT]
+   > **Kconfig & `sdkconfig` Mandatory Rule**: If any `Kconfig`, `Kconfig.projbuild`, `sdkconfig`, or `sdkconfig.*` defaults/override file is added, modified, or deleted, a `fullclean` build (`idf.py fullclean build` or `eim run "idf.py fullclean build"`) is **strictly mandatory** before building to ensure CMake cache re-evaluation.
+
+   ```bash
+   # Using direct idf.py (when IDF environment is exported):
+   idf.py fullclean build
+
+   # Or using eim wrapper from project root (requires BypassSandbox: true):
+   eim run "idf.py fullclean build"
+   ```
+
+3. **Extract Binary Footprint & Component Sizes**:
+   ```bash
+   idf.py size
+   idf.py size-components
+   ```
+
+---
+
+## 3. Qualitative Compilation Analysis Protocol
+
+After compilation, perform a systematic qualitative assessment across four key categories:
+
+### Category 1: Binary Memory & Storage Analysis
+- **DRAM (Data RAM)**: Monitor static memory usage. High DRAM usage (>80%) risks runtime stack/heap exhaustion.
+- **IRAM (Instruction RAM)**: Check code placed in IRAM (interrupt service routines, fast-path code).
+- **Flash (Code & Read-Only Data)**: Evaluate app binary partition occupation against partition table limits.
+- **Top Memory Consumers**: Review `idf.py size-components` output to identify top 3 memory-heavy components.
+
+### Category 2: Compiler Diagnostics & Warning Classification
+Classify log warnings into actionable categories:
+- **Deprecation Warnings**: Usage of legacy v4.x/v5.x driver APIs marked `IDF_DEPRECATED`.
+- **C/C++ Type & Boundary Warnings**: Implicit conversions, signed/unsigned comparisons, uninitialized variables.
+- **Header & Include Path Warnings**: Missing include guards, ambiguous header resolutions.
+
+### Category 3: Target Architecture & Hardware Checks
+- **Task Stack Allocation**: Ensure FreeRTOS task stacks performing string formatting or networking are allocated at least **2048 to 4096 bytes**.
+- **Strapping GPIO Safety**: Verify pin assignments do not use target-specific strapping pins for critical signals:
+  - *ESP32*: GPIO 0, 2, 5, 12, 15
+  - *ESP32-S2*: GPIO 0, 26, 45, 46
+  - *ESP32-S3*: GPIO 0, 3, 45, 46
+  - *ESP32-C3*: GPIO 2, 8, 9
+  - *ESP32-C6*: GPIO 8, 9, 15
+  - *ESP32-H2*: GPIO 8, 9, 25
+
+### Category 4: Dependency & Component Audit
+- Check `main/idf_component.yml` and `dependencies.lock`.
+- Ensure version constraints are strictly satisfied without unexpected transient dependency updates.
+
+---
+
+## 4. Standard Qualitative Build Report Format
+
+Format compilation results using the following markdown structure:
+
+```markdown
+# ESP-IDF v5.5.x Qualitative Build Report
+
+## Executive Summary
+- **Target MCU**: `<target_mcu>`
+- **ESP-IDF Version**: `v5.5.x`
+- **Build Status**: `SUCCESS` / `FAILED`
+- **Environment**: `eim` / `export.sh` / `MCP`
+
+## Memory Footprint Analysis
+| Memory Region | Used (Bytes) | Total (Bytes) | Usage (%) | Status |
+|---------------|--------------|---------------|-----------|--------|
+| DRAM          | X            | Y             | Z%        | OK / WARN |
+| IRAM          | X            | Y             | Z%        | OK / WARN |
+| Flash Code    | X            | Y             | Z%        | OK / WARN |
+
+### Top Component Memory Consumers
+1. `<component_1>`: X KB
+2. `<component_2>`: Y KB
+3. `<component_3>`: Z KB
+
+## Compiler Diagnostics & Warnings Summary
+- **Total Warnings**: N
+- **Deprecation Warnings**: N
+- **Type/Logic Warnings**: N
+
+## Architectural & Safety Verification
+- **FreeRTOS Stack Allocation**: Compliant / Needs Review
+- **Strapping GPIO Check**: Clear / Conflict Detected
+- **Component Dependency Status**: Locked & Clean
+```

--- a/.agents/skills/requirement-grilling/SKILL.md
+++ b/.agents/skills/requirement-grilling/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: requirement-grilling
+description: Guides the agent to perform interactive requirement grilling during the planning phase for complex features, architectural setups, and formalize agent scope, constraints, and traceability tracking in Markdown.
+---
+
+# Requirement Grilling & Interactive Planning Skill
+
+When this skill is activated or when starting a complex architectural task:
+
+1. **Pause Implementation**: Do not begin writing code or editing files immediately.
+2. **Formulate 3-5 Specific Questions**:
+   - Technical constraints (framework versions, hardware targets, OS compatibility).
+   - Architectural preferences (design patterns, file structure, state management).
+   - Operational scope boundaries, edge cases, and external dependencies.
+3. **Wait for Clarification**: Incorporate the user's responses into the final plan.
+4. **Generate / Update Markdown Tracking Files**:
+   - **`REQUIREMENTS.md`**: Formalize system requirements, operational boundaries, and an **Implementation Traceability Matrix** mapping requirements directly to specific source code/config files and verification methods.
+   - **`CONSTRAINTS.md`**: Document platform & tooling constraints, hardware safety rules, and software architecture constraints.
+   - **Root `README.md` / `PROJECT_SUMMARY.md`**: Ensure repository-level summaries accurately describe agent scope boundaries, technical stack, and repo structure.

--- a/.agents/skills/rule-harvesting/SKILL.md
+++ b/.agents/skills/rule-harvesting/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rule-harvesting
+description: Specialized workflow for discovering, extracting, generalizing, and cataloging new rules, constraints, and skills from specific or all workspace project repositories into antigravity-rules with user selection and approval.
+---
+
+# Workspace Rule & Skill Harvesting Skill
+
+Use this skill when auditing workspace project repositories—either targeting a single specified project or scanning across all workspace repositories—to discover emerging practices, unique operational constraints, or localized `.geminirules` and propose them for centralized integration in `antigravity-rules`.
+
+---
+
+## Operating Modes
+
+- **Targeted Project Mode**: Pass a specific target project directory (e.g. `/home/martinroger/Documents/superPod` or `CAN-logger-R56`). The workflow focuses specifically on discovering, extracting, and generalizing rules from that designated repository.
+- **Full Workspace Audit Mode**: Scan all project repositories in the workspace root (e.g., `/home/martinroger/Documents/*`) to audit cross-project practices and gather rules systematically.
+
+---
+
+## Harvesting Workflow
+
+### 1. Workspace Discovery & Scanning
+Scan the specified target project (or all workspace projects in full audit mode) for rule definitions, documentation artifacts, and specialized configurations:
+- **Local Rule Definitions**: Search for `.geminirules` or `.gemini/rules/*.geminirules` files inside the target directory.
+- **Local Skill Packages**: Search for custom skills inside `.gemini/skills/*/SKILL.md` or `skills/*/SKILL.md`.
+- **Constraint & Specification Documents**: Inspect `REQUIREMENTS.md`, `CONSTRAINTS.md`, `TOO.MD`, `SCENARIOS.md`, and top-level `README.md` files.
+- **Build & Dependency Configs**: Inspect `CMakeLists.txt`, `sdkconfig`, `package.json`, `idf_component.yml`, and `dependencies.lock` for platform-specific edge cases or recurring fix patterns.
+
+### 2. Analysis & Deduplication
+Compare discovered rules and constraints against existing centralized rulesets in `antigravity-rules`:
+- **[`rules/base.geminirules`](../../rules/base.geminirules)**: Core execution quality, requirement grilling, debugging, log inspection, max build retries, and industry protocol nomenclature.
+- **[`rules/documentation.geminirules`](../../rules/documentation.geminirules)**: Markdown scope & constraint tracking, user-facing artifact previews, portable relative links, human-focused sub-project README / `TOO.MD` separation, Doxygen `@param` defaults, and `SCENARIOS.md` sequence diagrams.
+- **[`rules/esp-idf.geminirules`](../../rules/esp-idf.geminirules)**: ESP32 hardware target, virtual environment (`eim`), `managed_components/` read-only boundary, FreeRTOS core pinning, strapping pin verification, dependency matrices, and HTTP server URI handler capacity checks.
+
+### 3. Classification & Generalization
+Evaluate each candidate practice and classify it into one of four tiers:
+1. **Universal Base Rule**: Core execution, debugging, or code quality rule applicable across all projects. (Target: `rules/base.geminirules`).
+2. **Documentation Rule**: Standards governing Markdown formatting, previews, links, or documentation structures. (Target: `rules/documentation.geminirules`).
+3. **Platform/Domain-Specific Rule**: Rules specific to a hardware target, framework, or technology stack (e.g. ESP-IDF, Python, Web/React). (Target: `rules/<platform>.geminirules`).
+4. **New Standalone Skill**: Recurring multi-step procedures or domain-specific workflows that warrant a dedicated `skills/<skill-name>/SKILL.md` package.
+
+> [!TIP]
+> **Generalization Principle**: Filter out hyper-project-specific naming (e.g. specific CAN message IDs or internal variable names) and rewrite the rule into a clean, reusable specification that applies broadly across similar projects or domains.
+
+### 4. Proposal Generation & User Selection (No Autonomous Commit)
+> [!IMPORTANT]
+> **Human-in-the-Loop Constraint**: Do NOT autonomously commit or overwrite rules/skills in `antigravity-rules` without user selection and confirmation.
+- **Render Proposal Artifact**: Per Section 2 of `rules/documentation.geminirules` (*Formatted Markdown Presentation*), generate a user-facing rendered Artifact (`user_facing: true`, `request_feedback: true`) detailing all newly harvested rules, skills, and catalog updates formatted directly as native Markdown elements.
+- **User Selection & Approval**: Present the proposal for the user to review, select specific rules/skills to keep, modify, or discard.
+
+### 5. Implementation, Cataloging & Global Sync (Post-Approval)
+Upon explicit user approval and selection:
+- Update target `.geminirules` files in `rules/`.
+- Create new skill packages under `skills/<skill-name>/SKILL.md`.
+- Update `README.md` catalog tables.
+- Execute `./scripts/sync-global.sh` to refresh global symlinks in `~/.gemini/antigravity/skills/`.
+- Summarize all exact file changes and request explicit user confirmation before creating a Git commit.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,116 @@
+# Antigravity Workspace Rules
+
+## 1. Base Antigravity Rules & Core Constraints
+
+### Requirement Grilling & Planning Phase
+- **Mandatory Interview**: Before generating multi-file implementations or writing code for non-trivial tasks, grill me on requirements!
+- Ask targeted questions regarding:
+  - Scope and core constraints.
+  - Expected output formats or architecture patterns.
+  - Potential edge cases or dependencies.
+
+### Error Diagnostics & Log Inspection
+- Never form a diagnostic hypothesis for a runtime failure or test breakage without reading the full, un-truncated error log.
+- Your very first action when an error occurs must be to fetch and read the exact logs.
+- Do not apply superficial patches or mask symptoms. Fix the root cause.
+- **Max Build Retry Safety Ceiling**: If a build or compilation command fails 10 consecutive times, STOP tool execution immediately. Present a concise summary of compilation failures and request user guidance before attempting further code modifications.
+
+### Code & Method Signature Integrity
+- Maintain existing comments and docstrings unless explicitly asked to modify them.
+- Verify method signatures and object properties before calling them.
+
+### Standard Protocol & Industry Specification Nomenclature
+- **Standard Name Alignment**: When implementing code based on an established standard or industry specification (e.g. ISO 14230-3 / KWP2000, ISO 15765, HTTP), strictly adopt the official protocol service and parameter names (e.g., `readDataByLocalIdentifier`, `dynamicallyDefineLocalIdentifier`, `recordLocalIdentifier`, `transmissionMode`, `responseCode`) throughout method declarations and variable names.
+
+### Multi-Agent & Subagent Execution Standards
+- **Sequential Build Enforcement**: Subagents are strictly prohibited from executing build, compilation, or flash commands concurrently. All verification builds must be run sequentially or yielded to the parent overseer agent to execute.
+- **Workspace & Branch Isolation**: Subagents are strictly restricted to the workspace root directory (must not read, write, or inspect files outside the repository) and must operate on isolated feature branches, submitting work via Pull Requests or structured diff reviews for parent overseer merging.
+
+---
+
+## 2. Documentation & Presentation Standards
+
+### Agent Scope, Constraints & Traceability Tracking (Markdown)
+- **Markdown Requirement & Constraint Tracking**: Document and track requirements, scope boundaries, and operational constraints used by the agent in explicit Markdown files (e.g. `REQUIREMENTS.md`, `CONSTRAINTS.md`, or inside `docs/`). Focus primarily on agent scope, design rules, platform/tooling constraints, and operational boundaries rather than exhaustive end-user feature manuals.
+- **Repo-Level Agent & Scope Summaries**: Maintain a top-level Markdown summary (`README.md` or `PROJECT_SUMMARY.md`) at the repository root detailing the project purpose, agent scope boundaries, technical constraints, and repo structure.
+- **Implementation Traceability**: Maintain clear traceability between agent constraints/requirements and their corresponding code implementations (e.g. in a Traceability Matrix or doc references). Keep documentation updated whenever agent scope or project constraints evolve.
+
+### Formatted Markdown Presentation
+- **Presentation Preference**: Whenever creating or updating a Markdown (`.md`) file in the workspace, always generate/update a corresponding **Artifact** (`user_facing: true`).
+- **Formatted Preview**: Present the output to the user as a rendered Artifact rather than relying only on the raw file diff view, so the user can immediately view formatted headings, tables, alerts, and rendered Markdown directly in the UI pane. Render the Markdown content directly as native Markdown elements (do NOT wrap the entire preview inside markdown code blocks).
+- **Workspace Sync**: Continue writing/updating the actual `.md` file in the workspace as requested, while maintaining the rendered Artifact for visual review.
+
+### Portable Relative Markdown Links
+- **Relative Path Invariant**: All file references inside repository Markdown (`.md`) files MUST use relative file paths (e.g., `[TOO.MD](TOO.MD)` or `[main/main.cpp](main/main.cpp)`).
+- **No Absolute Filesystem URLs**: NEVER commit absolute local filesystem URLs (e.g. `file:///home/user/...`) inside repository documentation to preserve author privacy and ensure links render correctly on GitHub.
+
+### Sub-Project & Module Documentation (`README.md` & `TOO.MD`)
+- **Sub-Project `README.md` Content**: `README.md` files located at the root of individual sub-projects or modules MUST remain lightweight, technical, and human-focused. They should describe subproject purpose, target architecture, hardware/network configuration, and key capabilities.
+- **Exclusion of Agent Instructions**: Sub-project `README.md` files MUST NOT contain agentic prompt instructions, internal rule citations (e.g., "Rule 6"), or AI operational constraint references. Agent-specific guidelines belong in repo-level files (`REQUIREMENTS.md`, top-level `README.md`, or `.geminirules`).
+- **Theory of Operation (`TOO.MD`) Requirement**: Each active sub-project and major shared component MUST maintain a `TOO.MD` (or `OTA_TOO.MD`) detailing system architecture, hardware subsystems, signal processing, data/bus ingestion and dispatch loops, API endpoints, and sequence diagrams (including protocol handshakes and timeout/error escape points).
+
+### Doxygen & API Code Documentation
+- **Explicit Default Value Explanations**: When writing Doxygen docstrings for functions with default parameter values, explicitly document the default value inside the `@param` tag (e.g., `@param[in] target_id Target ECU address byte (Default: 0x12)`).
+- **Public Header Coverage**: All public headers and exported component interfaces must include Doxygen comments describing parameters, return values, thread-safety, and side effects.
+
+### State Machine & Protocol Sequence Diagrams (`SCENARIOS.md`)
+- **Complex Flow Coverage**: Modules or components implementing non-trivial state machines, diagnostic daemons, or multi-step protocols MUST maintain sequence diagrams (e.g., inside `docs/SCENARIOS.md` or `TOO.MD`).
+- **Mermaid Sequence Diagrams**: Include Mermaid time sequence diagrams detailing normal initialization/handshakes, stream loss/broadcast timeouts, active read timeouts, error response handling (`0x7F`), payload validation failures, and pending/busy state transitions (`0x78`).
+
+### Directory Structure & Root Folder Cleanliness
+- **Subfolder Placement**: Project documentation MUST be organized within a `/docs/` subfolder. Likewise, any created ESP components (or custom project components) MUST reside in their respective subfolders (e.g. `/components/` or `/main/`).
+- **Root Folder Restrictions**: In general, ONLY `README.md` and/or standard licensing files (e.g., `LICENSE`, `LICENSE.md`) are allowed at the root level of the project folder. All other Markdown documents, specifications, architecture docs, or sub-component documentation must be placed in `/docs/` or their respective component directory.
+
+### Post-Build & Pre-Commit Documentation Sync
+- **Architectural Sync Verification**: When large architectural changes are made that might affect components or the main program structure, a documentation verification pass MUST be performed so that `.md` documents stay in sync with the codebase changes.
+- **Verification Timing**: This documentation verification pass MUST be completed:
+  1. **AFTER a successful build** (when applicable/adequate for the project).
+  2. **ALWAYS before any git commit or git push** (when relevant).
+
+---
+
+## 3. ESP-IDF & ESP32 Specific Project Rules
+
+### Hardware & Target Verification
+- Ask or confirm target SoC: ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6, ESP32-H2, etc.
+- Ask or confirm target ESP-IDF version line (< v5.5, >= v5.5, or >= v6.0).
+
+### MCP Server & Documentation Protocol
+- **Documentation Lookup**: If the `espressif-docs` MCP server is available, use `search_espressif_sources` as the authoritative source for command flags, `sdkconfig` options, and API specifications.
+- **Build Execution**: Check if an ESP-IDF Build MCP server is available. If present, prefer using its native MCP tools for building, flashing, and configuring targets.
+
+### Virtual Environment Execution Standards & Build Commands
+- **ESP-IDF Build Execution via `eim`**: If an ESP-IDF Build MCP server is NOT available, run `eim run "idf.py fullclean build"` (or `eim exec -- idf.py build`) from the project root directory. Because `eim` accesses toolchains and configurations stored in `~/.espressif`, `eim` commands MUST be executed in sandbox bypass mode (`BypassSandbox: true`).
+- **ESP-IDF Environment Sourcing**: When direct `idf.py` is available in exported shell environments (`. $IDF_PATH/export.sh`), run `idf.py fullclean build`.
+- **Kconfig / `sdkconfig` Mandatory `fullclean` Rule**: If any `Kconfig`, `Kconfig.projbuild`, `sdkconfig`, or `sdkconfig.*` defaults/override file is added, modified, or deleted, a `fullclean` build (`idf.py fullclean build` or `eim run "idf.py fullclean build"`) is **strictly mandatory** before building to ensure CMake cache re-evaluation.
+- **Session Start & Branch Switch Clean Invariant (`fullclean`)**: At the start of a new development session, immediately after switching Git branches, or when changing target chip / SDK configuration, ALWAYS execute a full clean (`idf.py fullclean` or `eim run "idf.py fullclean" <env>`) prior to building (`idf.py build`). This purges stale CMake caches, outdated Kconfig generated headers, and Ninja build objects to prevent false compilation failures or linker mismatches.
+
+### Project File Output Standards & Directory Boundaries
+- Always ensure ESP-IDF projects maintain standard structure:
+  - `CMakeLists.txt` at root.
+  - `main/CMakeLists.txt` registering components and sources.
+  - `main/main.c` or `main/main.cpp`.
+  - `sdkconfig.defaults` for reproducible configuration.
+- **`managed_components/` Read-Only Boundary**: `managed_components/` is strictly READ-ONLY. Never modify, patch, or edit files inside `managed_components/`. Solve component dependency or build issues in main application code, wrapper files, `Kconfig`, or via `main/idf_component.yml`. Revert any accidental modifications inside `managed_components/` immediately.
+- **Kconfig Embedded Asset Path Resolution**: When using Kconfig to specify custom relative file paths for embedded build assets (e.g., `EMBED_TXTFILES` or `EMBED_FILES`), CMake scripts MUST resolve paths relative to `${PROJECT_DIR}` and verify file existence before calling `target_add_binary_data()` to prevent silent build or linker failures.
+
+### Peripheral & Target-Specific Pinout Protocol
+- Pinouts, I2C/SPI bus speeds, and UART baud rates MUST be explicitly defined in header macros or `Kconfig`.
+- **Target-Specific Strapping Pin Verification**: Always check strapping GPIO assignments against the *active build target chip architecture* (e.g. ESP32: GPIO 0,2,5,12,15; ESP32-S3: GPIO 0,3,45,46; ESP32-C3: GPIO 2,8,9; ESP32-C6: GPIO 8,9,15). Do not apply a generic blanket strapping list across different MCUs.
+- **FreeRTOS Core Pinning & Task Stack Allocation**:
+  - Parametrize FreeRTOS task core allocations via `Kconfig` (e.g. Core 0 vs Core 1) to prevent race conditions and CPU spin loops on multi-core targets (e.g., ESP32 / ESP32-S3).
+  - Verify task stack sizes for FreeRTOS tasks (minimum 2048–4096 bytes for tasks calling C stdlib/logging) to prevent stack overflow.
+- **TWAI/CAN Bus-Off & Disconnected Hardware Recovery**: Protocol daemons and CAN/TWAI drivers MUST handle disconnected hardware states (`TWAI_STATE_BUS_OFF` or missing transceiver ACK) gracefully. Disconnected hardware or un-terminated bench setups must never cause infinite retry loops, watchdog resets, or task deadlocks. Drivers must include timeout limits, error state reporting, and automatic or manual recovery triggers (e.g. `twai_initiate_recovery()`).
+
+### Global README Sub-Project External Dependency Matrix
+- **Dependency Summary Table**: For projects containing multiple sub-projects or component packages, the top-level repository `README.md` MUST contain and maintain a structured summary table of external dependencies across all sub-projects.
+- **Required Columns**:
+  - **Sub-Project**: Name of the sub-project directory.
+  - **External Dependency**: Name of the component package invoked via `idf_component.yml`.
+  - **Locally Installed Version**: Exact version tag or short git commit SHA currently installed in `managed_components` / `dependencies.lock`.
+  - **Version Requirement**: The constraint or version specification declared in `idf_component.yml` (when available).
+
+### ESP-IDF HTTP Server URI Handler Capacity Check
+- **URI Handler Counting**: When configuring `httpd_config_t` for `esp_http_server`, count the total number of URI handlers to be registered across all modules (REST API endpoints, static SPIFFS assets, and WebSocket `/ws` endpoints).
+- **Explicit Capacity Allocation**: `HTTPD_DEFAULT_CONFIG()` defaults `httpd_cfg.max_uri_handlers = 8`. If the total number of registered URI handlers exceeds 8, explicitly set `httpd_cfg.max_uri_handlers` to a sufficient capacity (e.g., `httpd_cfg.max_uri_handlers = 16;`) before calling `httpd_start()` to prevent `W (httpd_uri): no slots left for registering handler` registration failures.
+

--- a/factory apps/ITF factory app/main/main.cpp
+++ b/factory apps/ITF factory app/main/main.cpp
@@ -619,6 +619,13 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 	{
 		// Construct pointer at the first supposed numerical character
 		const char *newFLCFToParse = new_fuel_level_corr_ptr + sizeof("new_fuel_level_corr=") - 1;
+		if (newFLCFToParse[0] == '\0' || newFLCFToParse[0] == '&')
+		{
+			ESP_LOGE(__func__, "Empty value supplied for new_fuel_level_corr");
+			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty value in set request");
+			nvs_close(h);
+			return ESP_FAIL;
+		}
 		// atol is not checking anything. Let's check that at least the first character is either numerical or +-
 		if ((newFLCFToParse[0] == '-') || (newFLCFToParse[0] == '+') || ((newFLCFToParse[0] >= '0') && (newFLCFToParse[0] <= '9')))
 		{
@@ -634,7 +641,7 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 		}
 		else
 		{
-			ESP_LOGE(__func__, "Invalid starting character %s for atol, reporting error", newFLCFToParse[0]);
+			ESP_LOGE(__func__, "Invalid starting character '%c' (0x%02X) for atol, reporting error", newFLCFToParse[0], (unsigned char)newFLCFToParse[0]);
 			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid characters in set request");
 			nvs_close(h);
 			return ESP_FAIL;
@@ -643,6 +650,13 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 	if (new_low_fuel_th_ptr != NULL)
 	{
 		const char *newLFTToParse = new_low_fuel_th_ptr + sizeof("new_low_fuel_threshold=") - 1;
+		if (newLFTToParse[0] == '\0' || newLFTToParse[0] == '&')
+		{
+			ESP_LOGE(__func__, "Empty value supplied for new_low_fuel_threshold");
+			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty value in set request");
+			nvs_close(h);
+			return ESP_FAIL;
+		}
 		if ((newLFTToParse[0] == '-') || (newLFTToParse[0] == '+') || ((newLFTToParse[0] >= '0') && (newLFTToParse[0] <= '9')))
 		{
 			detectedNumber = atol(newLFTToParse);
@@ -651,12 +665,12 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 			if (detectedNumber > UINT16_MAX)
 				detectedNumber = UINT16_MAX;
 			nvs_set_u16(h, "lo_fuel_th", (uint16_t)detectedNumber);
-			ESP_LOGI(__func__, "Low fuel level threshold updated to %u %", (uint16_t)detectedNumber);
+			ESP_LOGI(__func__, "Low fuel level threshold updated to %u %%", (uint16_t)detectedNumber);
 			nvs_commit(h);
 		}
 		else
 		{
-			ESP_LOGE(__func__, "Invalid starting character %s for atol, reporting error", newLFTToParse[0]);
+			ESP_LOGE(__func__, "Invalid starting character '%c' (0x%02X) for atol, reporting error", newLFTToParse[0], (unsigned char)newLFTToParse[0]);
 			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid characters in set request");
 			nvs_close(h);
 			return ESP_FAIL;
@@ -665,6 +679,13 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 	if (new_overtemp_th_ptr != NULL)
 	{
 		const char *newOVTToParse = new_overtemp_th_ptr + sizeof("new_overtemp_threshold=") - 1;
+		if (newOVTToParse[0] == '\0' || newOVTToParse[0] == '&')
+		{
+			ESP_LOGE(__func__, "Empty value supplied for new_overtemp_threshold");
+			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty value in set request");
+			nvs_close(h);
+			return ESP_FAIL;
+		}
 		if ((newOVTToParse[0] == '-') || (newOVTToParse[0] == '+') || ((newOVTToParse[0] >= '0') && (newOVTToParse[0] <= '9')))
 		{
 			detectedNumber = atol(newOVTToParse);
@@ -678,7 +699,7 @@ static esp_err_t set_cal_post_handler(httpd_req_t *req)
 		}
 		else
 		{
-			ESP_LOGE(__func__, "Invalid starting character %s for atol, reporting error", newOVTToParse[0]);
+			ESP_LOGE(__func__, "Invalid starting character '%c' (0x%02X) for atol, reporting error", newOVTToParse[0], (unsigned char)newOVTToParse[0]);
 			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid characters in set request");
 			nvs_close(h);
 			return ESP_FAIL;
@@ -1684,6 +1705,13 @@ static esp_err_t set_trip_odo_post_handler(httpd_req_t *req)
 	{
 		// Construct pointer at the first supposed numerical character
 		const char *tripToParse = new_trip_ptr + sizeof("new_trip=") - 1;
+		if (tripToParse[0] == '\0' || tripToParse[0] == '&')
+		{
+			ESP_LOGE(__func__, "Empty value supplied for new_trip");
+			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty value in trip set request");
+			nvs_close(h);
+			return ESP_FAIL;
+		}
 		// atol is not checking anything. Let's check that at least the first character is either numerical or +-
 		if ((tripToParse[0] == '-') || (tripToParse[0] == '+') || ((tripToParse[0] >= '0') && (tripToParse[0] <= '9')))
 		{
@@ -1699,7 +1727,7 @@ static esp_err_t set_trip_odo_post_handler(httpd_req_t *req)
 		}
 		else
 		{
-			ESP_LOGE(__func__, "Invalid starting character %s for atol, reporting error", tripToParse[0]);
+			ESP_LOGE(__func__, "Invalid starting character '%c' (0x%02X) for atol, reporting error", tripToParse[0], (unsigned char)tripToParse[0]);
 			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid characters in trip set request");
 			nvs_close(h);
 			return ESP_FAIL;
@@ -1708,6 +1736,13 @@ static esp_err_t set_trip_odo_post_handler(httpd_req_t *req)
 	if (new_odo_ptr != NULL)
 	{
 		const char *odoToParse = new_odo_ptr + sizeof("new_odo=") - 1;
+		if (odoToParse[0] == '\0' || odoToParse[0] == '&')
+		{
+			ESP_LOGE(__func__, "Empty value supplied for new_odo");
+			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Empty value in odo set request");
+			nvs_close(h);
+			return ESP_FAIL;
+		}
 		if ((odoToParse[0] == '-') || (odoToParse[0] == '+') || ((odoToParse[0] >= '0') && (odoToParse[0] <= '9')))
 		{
 			detectedNumber = atol(odoToParse);
@@ -1721,7 +1756,7 @@ static esp_err_t set_trip_odo_post_handler(httpd_req_t *req)
 		}
 		else
 		{
-			ESP_LOGE(__func__, "Invalid starting character %s for atol, reporting error", odoToParse[0]);
+			ESP_LOGE(__func__, "Invalid starting character '%c' (0x%02X) for atol, reporting error", odoToParse[0], (unsigned char)odoToParse[0]);
 			httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid characters in odo set request");
 			nvs_close(h);
 			return ESP_FAIL;
@@ -1849,6 +1884,63 @@ extern "C" void app_main(void)
 		ESP_LOGE(__func__, "Could not init nvs_odo NVS, erasing and retrying. - %ld", err);
 		nvs_flash_erase_partition("nvs_odo");
 		nvs_flash_init_partition("nvs_odo");
+	}
+
+	// Auto-populate default NVS keys if not yet initialized
+	ESP_LOGI(__func__, "Checking and populating NVS defaults...");
+	nvs_handle_t h_storage;
+	if (nvs_open("storage", NVS_READWRITE, &h_storage) == ESP_OK)
+	{
+		uint16_t val16 = 0;
+		if (nvs_get_u16(h_storage, "fuel_comp", &val16) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_u16(h_storage, "fuel_comp", 1000);
+			ESP_LOGI(__func__, "Populated default NVS key fuel_comp: 1000");
+		}
+		if (nvs_get_u16(h_storage, "lo_fuel_th", &val16) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_u16(h_storage, "lo_fuel_th", 20);
+			ESP_LOGI(__func__, "Populated default NVS key lo_fuel_th: 20");
+		}
+		if (nvs_get_u16(h_storage, "overtemp_th", &val16) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_u16(h_storage, "overtemp_th", 106);
+			ESP_LOGI(__func__, "Populated default NVS key overtemp_th: 106");
+		}
+		int8_t val8 = 0;
+		if (nvs_get_i8(h_storage, "lastPart", &val8) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_i8(h_storage, "lastPart", -1);
+			ESP_LOGI(__func__, "Populated default NVS key lastPart: -1");
+		}
+		nvs_commit(h_storage);
+		nvs_close(h_storage);
+	}
+	else
+	{
+		ESP_LOGE(__func__, "Could not open default NVS storage namespace for defaults check");
+	}
+
+	nvs_handle_t h_odo;
+	if (nvs_open_from_partition("nvs_odo", "storage", NVS_READWRITE, &h_odo) == ESP_OK)
+	{
+		uint32_t val32 = 0;
+		if (nvs_get_u32(h_odo, "odometer_m", &val32) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_u32(h_odo, "odometer_m", 0);
+			ESP_LOGI(__func__, "Populated default NVS key odometer_m: 0");
+		}
+		if (nvs_get_u32(h_odo, "trip_m", &val32) == ESP_ERR_NVS_NOT_FOUND)
+		{
+			nvs_set_u32(h_odo, "trip_m", 0);
+			ESP_LOGI(__func__, "Populated default NVS key trip_m: 0");
+		}
+		nvs_commit(h_odo);
+		nvs_close(h_odo);
+	}
+	else
+	{
+		ESP_LOGE(__func__, "Could not open nvs_odo storage namespace for defaults check");
 	}
 
 	esp_netif_init();

--- a/factory apps/ITF factory app/main/web/index.html
+++ b/factory apps/ITF factory app/main/web/index.html
@@ -16,14 +16,12 @@
     <details>
         <summary>Odometer and trip</summary>
         <p>
-            Odometer : <mark id="odometer">-</mark> m <input id="new_odo" type="number"> <button type="button"
-                onclick="fetch('/set_trip_odo?new_odo='+document.getElementById('new_odo').value,{method:'POST'}).then(()=>fetch('/odometer').then(r => r.json()).then(j => { document.getElementById('odometer').innerText = j.odometer_m; document.getElementById('trip').innerText = j.trip_m }))">Set
-                odometer</button>
+            Odometer : <mark id="odometer">-</mark> m <input id="new_odo" type="number" min="0" step="1"> <button type="button"
+                onclick="updateOdometer()">Set odometer</button>
             <br>
 
-            Trip : <mark id="trip">-</mark> m <input id="new_trip" type="number"> <button type="button"
-                onclick="fetch('/set_trip_odo?new_trip='+document.getElementById('new_trip').value,{method:'POST'}).then(()=>fetch('/odometer').then(r => r.json()).then(j => { document.getElementById('odometer').innerText = j.odometer_m; document.getElementById('trip').innerText = j.trip_m }))">Set
-                trip</button>
+            Trip : <mark id="trip">-</mark> m <input id="new_trip" type="number" min="0" step="1"> <button type="button"
+                onclick="updateTrip()">Set trip</button>
         </p>
     </details>
 
@@ -31,14 +29,14 @@
         <summary>Calibration values</summary>
         <p>
             Fuel level correction factor : <mark><span id="fuel_level_corr">-</span>/1000</mark> <input
-                id="new_fuel_level_corr" type="number"> <button type="button"
-                onclick="fetch('/set_cal?new_fuel_level_corr='+document.getElementById('new_fuel_level_corr').value,{method:'POST'}).then(()=>refreshCalVariables())">Update</button><br>
+                id="new_fuel_level_corr" type="number" min="1" max="65535" step="1"> <button type="button"
+                onclick="updateCalParam('new_fuel_level_corr')">Update</button><br>
             Low fuel alarm threshold : <mark><span id="low_fuel_threshold">-</span>%</mark> <input
-                id="new_low_fuel_threshold" type="number"> <button type="button"
-                onclick="fetch('/set_cal?new_low_fuel_threshold='+document.getElementById('new_low_fuel_threshold').value,{method:'POST'}).then(()=>refreshCalVariables())">Update</button><br>
+                id="new_low_fuel_threshold" type="number" min="0" max="100" step="1"> <button type="button"
+                onclick="updateCalParam('new_low_fuel_threshold')">Update</button><br>
             Overtemp warning : <mark><span id="overtemp_threshold">-</span>°C</mark> <input id="new_overtemp_threshold"
-                type="number"> <button type="button"
-                onclick="fetch('/set_cal?new_overtemp_threshold='+document.getElementById('new_overtemp_threshold').value,{method:'POST'}).then(()=>refreshCalVariables())">Update</button><br>
+                type="number" min="0" max="250" step="1"> <button type="button"
+                onclick="updateCalParam('new_overtemp_threshold')">Update</button><br>
         </p>
     </details>
 
@@ -105,18 +103,71 @@
 
 
     <script>
+        function updateOdometer() {
+            var val = document.getElementById('new_odo').value;
+            if (val === '' || isNaN(val)) {
+                alert('Please enter a valid odometer number');
+                return;
+            }
+            fetch('/set_trip_odo?new_odo=' + encodeURIComponent(val), { method: 'POST' })
+                .then(r => {
+                    if (!r.ok) throw new Error('Update failed');
+                    return fetch('/odometer');
+                })
+                .then(r => r.json())
+                .then(j => {
+                    document.getElementById('odometer').innerText = j.odometer_m;
+                    document.getElementById('trip').innerText = j.trip_m;
+                })
+                .catch(e => alert('Error setting odometer: ' + e.message));
+        }
+
+        function updateTrip() {
+            var val = document.getElementById('new_trip').value;
+            if (val === '' || isNaN(val)) {
+                alert('Please enter a valid trip number');
+                return;
+            }
+            fetch('/set_trip_odo?new_trip=' + encodeURIComponent(val), { method: 'POST' })
+                .then(r => {
+                    if (!r.ok) throw new Error('Update failed');
+                    return fetch('/odometer');
+                })
+                .then(r => r.json())
+                .then(j => {
+                    document.getElementById('odometer').innerText = j.odometer_m;
+                    document.getElementById('trip').innerText = j.trip_m;
+                })
+                .catch(e => alert('Error setting trip: ' + e.message));
+        }
+
+        function updateCalParam(inputId) {
+            var input = document.getElementById(inputId);
+            var val = input.value;
+            if (val === '' || isNaN(val)) {
+                alert('Please enter a valid number');
+                return;
+            }
+            fetch('/set_cal?' + inputId + '=' + encodeURIComponent(val), { method: 'POST' })
+                .then(r => {
+                    if (!r.ok) throw new Error('Update failed');
+                    refreshCalVariables();
+                })
+                .catch(e => alert('Error updating parameter: ' + e.message));
+        }
+
         function refreshCalVariables() {
             fetch('/calibration').then(r => r.json()).then(j => {
-                if (j.fuel_level_corr) {
-                    document.getElementById('fuel_level_corr').innerText = j.fuel_level_corr || '-';
+                if (j.fuel_level_corr !== undefined) {
+                    document.getElementById('fuel_level_corr').innerText = j.fuel_level_corr;
                     document.getElementById('new_fuel_level_corr').value = parseInt(j.fuel_level_corr);
                 }
-                if (j.low_fuel_threshold) {
-                    document.getElementById('low_fuel_threshold').innerText = j.low_fuel_threshold || '-';
+                if (j.low_fuel_threshold !== undefined) {
+                    document.getElementById('low_fuel_threshold').innerText = j.low_fuel_threshold;
                     document.getElementById('new_low_fuel_threshold').value = parseInt(j.low_fuel_threshold);
                 }
-                if (j.overtemp_threshold) {
-                    document.getElementById('overtemp_threshold').innerText = j.overtemp_threshold || '-';
+                if (j.overtemp_threshold !== undefined) {
+                    document.getElementById('overtemp_threshold').innerText = j.overtemp_threshold;
                     document.getElementById('new_overtemp_threshold').value = parseInt(j.overtemp_threshold);
                 }
             });


### PR DESCRIPTION
## Summary of Changes

### 1. Fix Panic & Auto-Populate NVS Defaults (`factory apps/ITF factory app`)
- **Auto-populate NVS keys**: On freshly erased/flashed boards, `app_main()` now automatically inspects and commits default calibration and odometer keys (`fuel_comp: 1000`, `lo_fuel_th: 20`, `overtemp_th: 106`, `lastPart: -1`, `odometer_m: 0`, `trip_m: 0`).
- **Fix Format Specifier Dereference Panic**: Corrected `ESP_LOGE` in `set_cal_post_handler` and `set_trip_odo_post_handler` from `%s` to `'%c' (0x%02X)` when logging invalid starting characters.
- **Empty Query Parameter Guards**: Added server-side checks to reject empty strings (`val[0] == '\0' || val[0] == '&'`) with HTTP 400 Bad Request before calling `atol()`.
- **Frontend Validation**: Added client-side validation helpers in `main/web/index.html` preventing empty or `NaN` submissions.

### 2. Antigravity Workspace Rules & Development Skills
- Added repo-level [`GEMINI.md`](GEMINI.md) incorporating Base rules, Documentation standards, and ESP-IDF/ESP32 guidelines.
- Installed local development skills into `.agents/skills/`:
  - `esp-idf-v5-5-compile`
  - `esp-development`
  - `requirement-grilling`
  - `rule-harvesting`

---

## Verification
- Clean build verified via `eim run "idf.py fullclean build"` using ESP-IDF v5.5.5.
- Qualitative build analysis confirmed zero warnings in modified code and verified binary memory footprint within app partition constraints.